### PR TITLE
Prevent crash when passing undefined to console.log.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,9 +72,7 @@ module.exports = function() {
 
   function write(args) {
     // ensure all args are strings
-    var cleanArgs = args.map(function(item) {
-      return item.toString()
-    })
+    var cleanArgs = args.map(String)
 
     // try parsing it as tap
     var output = format.apply(null, cleanArgs)

--- a/test/index.js
+++ b/test/index.js
@@ -44,3 +44,10 @@ test('can parse tap output correctly', function(t) {
     t.end()
   }
 })
+
+test('console.log(undefined) does not throw', function (t) {
+  var tap = Tap()
+  console.log(undefined)
+  tap.detach()
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -5,37 +5,42 @@ var file = path.join(__dirname, 'tap.txt')
 var lines = fs.readFileSync(file, 'utf8').split('\n')
 
 var test = require('tape')
-var tap = require('../')()
+var Tap = require('../')
 
-var asserts = []
-var tests = []
-var result
 
-tap.on('test', function (test) {
-  tests.push(test)
-})
-tap.on('assert', function (assert) {
-  asserts.push(assert)
-})
+test('can parse tap output correctly', function(t) {
+  var tap = Tap()
 
-tap.on('complete', function (r) {
-  result = r
-  tap.detach()
-  ready()
-})
+  var asserts = []
+  var tests = []
+  var result
 
-lines.forEach(function (x) {
-  console.log(x)
-})
-
-function ready () {
-  test('should have some asserts', function (t) {
-    t.deepEqual(asserts[0], { name: 'got true', number: 1, ok: true, raw: 'ok 1 got true', test: 1, type: 'assert' })
-    t.deepEqual(asserts[1], { error: { actual: '51', at: { character: '5', file: 'basic.js', line: '5' }, expected: 'true', operator: 'equal', raw: '    operator: equal\n    expected: true\n    actual:   51\n    at: Test.<anonymous> (basic.js:5:5)' }, name: 'something wrong', number: 2, ok: false, raw: 'not ok 2 something wrong', test: 1, type: 'assert' })
-    t.deepEqual(asserts[2], { error: { actual: undefined, at: undefined, expected: undefined, operator: 'fail', raw: '    operator: fail' }, name: 'test timed out after 50ms', number: 3, ok: false, raw: 'not ok 3 test timed out after 50ms', test: 2, type: 'assert' })
-    t.deepEqual(tests[0], { name: 'first test', number: 1, raw: '# first test', type: 'test' })
-    t.deepEqual(result, { fail: 2, ok: false, pass: 1, total: 3 })
-    t.end()
+  tap.on('test', function (test) {
+    tests.push(test)
   })
-}
-  
+  tap.on('assert', function (assert) {
+    asserts.push(assert)
+  })
+
+  tap.on('complete', function (r) {
+    result = r
+    tap.detach()
+    ready()
+  })
+
+  lines.forEach(function (x) {
+    console.log(x)
+  })
+
+  function ready () {
+    t.test('should have some asserts', function (t) {
+      t.deepEqual(asserts[0], { name: 'got true', number: 1, ok: true, raw: 'ok 1 got true', test: 1, type: 'assert' })
+      t.deepEqual(asserts[1], { error: { actual: '51', at: { character: '5', file: 'basic.js', line: '5' }, expected: 'true', operator: 'equal', raw: '    operator: equal\n    expected: true\n    actual:   51\n    at: Test.<anonymous> (basic.js:5:5)' }, name: 'something wrong', number: 2, ok: false, raw: 'not ok 2 something wrong', test: 1, type: 'assert' })
+      t.deepEqual(asserts[2], { error: { actual: undefined, at: undefined, expected: undefined, operator: 'fail', raw: '    operator: fail' }, name: 'test timed out after 50ms', number: 3, ok: false, raw: 'not ok 3 test timed out after 50ms', test: 2, type: 'assert' })
+      t.deepEqual(tests[0], { name: 'first test', number: 1, raw: '# first test', type: 'test' })
+      t.deepEqual(result, { fail: 2, ok: false, pass: 1, total: 3 })
+      t.end()
+    })
+    t.end()
+  }
+})


### PR DESCRIPTION
If `console.log` encountered a anything without a `.toString` method, e.g. `undefined`,  it would throw an error:

```
/Users/timoxley/Projects/libs/tap-console-parser/index.js:76
      return item.toString()
                 ^
TypeError: Cannot read property 'toString' of undefined
    at /Users/timoxley/Projects/libs/tap-console-parser/index.js:76:18
    at Array.map (native)
    at write (/Users/timoxley/Projects/libs/tap-console-parser/index.js:75:26)
    at Console.console.log (/Users/timoxley/Projects/libs/tap-console-parser/index.js:46:7)
...
```

AFAIK it's best practice to use `String(thing)` over `thing.toString()` for this reason.
