### PR TITLE
Restore original console log

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function() {
   }
 
   function detach() {
-    console.log = nativeMethod.bind(console)
+    console.log = nativeMethod
   }
 
   attach()

--- a/test/index.js
+++ b/test/index.js
@@ -51,3 +51,12 @@ test('console.log(undefined) does not throw', function (t) {
   tap.detach()
   t.end()
 })
+
+test('console.log() works as usual after detach', function (t) {
+  var nativeMethod = console.log
+  var tap = Tap()
+  tap.detach()
+  t.strictEqual(console.log, nativeMethod)
+  console.log('# should not throw')
+  t.end()
+})


### PR DESCRIPTION
Bind is unnecessary if people are calling the `console.log` function as `console.log`
